### PR TITLE
Fix Python3 wrapper script in devel space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,3 @@ catkin_install_python(PROGRAMS
   bin/axcli
   DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
-
-# generate relay-script for each program
-set(EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/bin/axcli)
-configure_file(${catkin_EXTRAS_DIR}/templates/script.sh.in
-  ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_BIN_DESTINATION}/axcli
-  @ONLY)


### PR DESCRIPTION
Hi, I'm sending this PR here because the original repo seems dead.

In the develspace with Python3 axcli was broken because it was trying to use Python2 to execute this. The reason was that the wrapper script points to the original axcli script with the original shebang, instead of the rewritten one.

Nowadays catkin automatically generates the wrapper scripts for the devel space. This was implemented here: https://github.com/ros/catkin/pull/1044. By using the original wrapper script, axcli get's executed with the correct Python verison.